### PR TITLE
Update options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
+- Fixed compatibility with other license generators (see below).
+- **BC BREAK** Updated option names to be generator specific:
+  - `license` is now `ccLicense`.
+  - `licensePrompt` is now `ccLicensePrompt`.
+  - `work` is now `ccWork`.
 - Update `.gitattributes` file to exclude directories and files from dist.
 
 ## 1.0.1 - 2017-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 
-- Fixed compatibility with other license generators (see below).
+- Fixed compatibility with other license generators (see below) - #18
 - **BC BREAK** Updated option names to be generator specific:
   - `license` is now `ccLicense`.
   - `licensePrompt` is now `ccLicensePrompt`.
   - `work` is now `ccWork`.
+- Fixed `main` definition in `package.json` to point to
+  `generators/app/index.js`
 - Update `.gitattributes` file to exclude directories and files from dist.
 
 ## 1.0.1 - 2017-01-22

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ example code how to trigger this generator:
 
 ```js
 this.composeWith(require.resolve('generator-license-cc/generators/app'), {
-  name: 'Bob A',                      // (optional) Author's Name
-  work: 'ProjectX Documentation',     // (optional) Work Title
-  email: 'bob@example.org',           // (optional) Author's Email
-  website: 'http://www.example.org',  // (optional) Author's Website
-  year: '2016-2017',                  // (optional) Year(s) to include
-  licensePrompt: 'Choose a License:', // (optional) custom license prompt text
-  output: 'docs/LICENSE'              // (optional) choose output file for license
+  name: 'Bob A',                        // (optional) Author's Name
+  ccWork: 'ProjectX Documentation',     // (optional) Creative Work Title
+  email: 'bob@example.org',             // (optional) Author's Email
+  website: 'http://www.example.org',    // (optional) Author's Website
+  year: '2016-2017',                    // (optional) Year(s) to include
+  ccLicensePrompt: 'Choose a License:', // (optional) custom license prompt text
+  ccLicense: 'chooser',                 // (optional) choose CC license (spdx) or 'chooser'
+  output: 'docs/LICENSE'                // (optional) choose output file
 });
 ```
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -36,7 +36,7 @@ module.exports = Generator.extend({
       required: true
     });
 
-    this.option('work', {
+    this.option('ccWork', {
       type: String,
       desc: 'Title of Creative Work',
       required: true
@@ -61,14 +61,14 @@ module.exports = Generator.extend({
       defaults: (new Date()).getFullYear()
     });
 
-    this.option('licensePrompt', {
+    this.option('ccLicensePrompt', {
       type: String,
       desc: 'License prompt text',
       required: true,
       defaults: 'Choose a license for your Creative Work:'
     });
 
-    this.option('license', {
+    this.option('ccLicense', {
       type: String,
       desc: 'License to Generate: CC-BY-4.0, CC-BY-SA-4.0, CC-BY-ND-4.0, CC-BY-NC-4.0, CC-BY-NC-SA-4.0, CC-BY-NC-ND-4.0, CC0-1.0',
       required: true
@@ -93,7 +93,7 @@ module.exports = Generator.extend({
       this.options.email = this._initOptions.email;
     }
 
-    this.options.work = this._initOptions.work;
+    this.options.ccWork = this._initOptions.ccWork;
     this.options.year = this._initOptions.year;
     this.options.website = this._initOptions.website;
     this.options.output = this._initOptions.output || this.options.output;
@@ -115,10 +115,10 @@ module.exports = Generator.extend({
           when: !this._initOptions.name
         },
         {
-          name: 'work',
+          name: 'ccWork',
           message: 'Title of Creative Work:',
-          default: this.options.work,
-          when: !this._initOptions.work
+          default: this.options.ccWork,
+          when: !this._initOptions.ccWork
         },
         {
           name: 'year',
@@ -130,11 +130,11 @@ module.exports = Generator.extend({
 
       return this.prompt(prompts).then(function (answers) {
         if (answers.name) {
-          this.options.name = answers.name.trim();
+          this.options.name = answers.name;
         }
 
-        if (answers.work) {
-          this.options.work = answers.work.trim();
+        if (answers.ccWork) {
+          this.options.ccWork = answers.ccWork;
         }
 
         if (answers.year) {
@@ -189,15 +189,15 @@ module.exports = Generator.extend({
         }.bind(this));
       }
     },
-    licensePrompt() {
+    ccLicensePrompt() {
       var prompts = [
         {
           type: 'list',
-          name: 'license',
-          message: this.options.licensePrompt,
-          default: this.options.license,
+          name: 'ccLicense',
+          message: this.options.ccLicensePrompt,
+          default: this.options.ccLicense,
           choices: licenses,
-          when: !this._initOptions.license
+          when: !this._initOptions.ccLicense
         },
         {
           type: 'list',
@@ -206,7 +206,7 @@ module.exports = Generator.extend({
           default: 'Yes',
           choices: chooserAdaptations,
           when: function (answers) {
-            return answers.license === 'chooser';
+            return answers.ccLicense === 'chooser';
           }
         },
         {
@@ -216,7 +216,7 @@ module.exports = Generator.extend({
           default: 'Yes',
           choices: chooserCommercial,
           when: function (answers) {
-            return answers.license === 'chooser';
+            return answers.ccLicense === 'chooser';
           }
         },
         {
@@ -229,32 +229,32 @@ module.exports = Generator.extend({
       ];
 
       return this.prompt(prompts).then(function (answers) {
-        if (answers.license) {
-          if (answers.license === 'chooser') {
+        if (answers.ccLicense) {
+          if (answers.ccLicense === 'chooser') {
             if (answers.chooserAdaptations === 'Yes' &&
               answers.chooserCommercial === 'Yes') {
-              this.options.license = 'CC-BY-4.0';
+              this.options.ccLicense = 'CC-BY-4.0';
             } else if (answers.chooserAdaptations === 'Yes' &&
               answers.chooserCommercial === 'No') {
-              this.options.license = 'CC-BY-NC-4.0';
+              this.options.ccLicense = 'CC-BY-NC-4.0';
             } else if (answers.chooserAdaptations === 'No' &&
               answers.chooserCommercial === 'Yes') {
-              this.options.license = 'CC-BY-ND-4.0';
+              this.options.ccLicense = 'CC-BY-ND-4.0';
             } else if (answers.chooserAdaptations === 'No' &&
               answers.chooserCommercial === 'No') {
-              this.options.license = 'CC-BY-NC-ND-4.0';
+              this.options.ccLicense = 'CC-BY-NC-ND-4.0';
             } else if (answers.chooserAdaptations === 'Share' &&
               answers.chooserCommercial === 'Yes') {
-              this.options.license = 'CC-BY-SA-4.0';
+              this.options.ccLicense = 'CC-BY-SA-4.0';
             } else if (answers.chooserAdaptations === 'Share' &&
               answers.chooserCommercial === 'No') {
-              this.options.license = 'CC-BY-NC-SA-4.0';
+              this.options.ccLicense = 'CC-BY-NC-SA-4.0';
             }
             this.log();
-            this.log('> We have picked ' + chalk.yellow(this.options.license) + ' License!');
+            this.log('> We have picked ' + chalk.yellow(this.options.ccLicense) + ' License!');
             this.log();
           } else {
-            this.options.license = answers.license;
+            this.options.ccLicense = answers.ccLicense;
           }
         }
 
@@ -267,7 +267,7 @@ module.exports = Generator.extend({
 
   writing: function () {
     // check license file
-    var filename = this.options.license + '.txt';
+    var filename = this.options.ccLicense + '.txt';
     if (this.fs.exists(this.templatePath(filename))) {
       // combine author data
       let author = this.options.name;
@@ -285,12 +285,12 @@ module.exports = Generator.extend({
         {
           year: this.options.year,
           author: author,
-          work: this.options.work
+          work: this.options.ccWork
         }
       );
 
       this.log();
-      this.log('> ' + chalk.yellow(this.options.license) + ' License has been generated (file: ' + chalk.yellow(this.options.output) + ')');
+      this.log('> ' + chalk.yellow(this.options.ccLicense) + ' License has been generated (file: ' + chalk.yellow(this.options.output) + ')');
       this.log('> Make sure to ' + chalk.red('verify the license is suitable!'));
       this.log();
     } else {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "files": [
     "generators"
   ],
-  "main": "generators/index.js",
+  "main": "generators/app/index.js",
   "keywords": [
     "yeoman-generator",
     "yeoman",

--- a/test/app-chooser.js
+++ b/test/app-chooser.js
@@ -18,11 +18,11 @@ describe('generator-license-cc:chooser CC-BY-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicense,
+        ccLicense: testLicense,
         chooserAdaptations: 'Yes',
         chooserCommercial: 'Yes',
         output: testOutput
@@ -42,11 +42,11 @@ describe('generator-license-cc:chooser CC-BY-SA-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicense,
+        ccLicense: testLicense,
         chooserAdaptations: 'Share',
         chooserCommercial: 'Yes',
         output: testOutput
@@ -66,11 +66,11 @@ describe('generator-license-cc:chooser CC-BY-ND-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicense,
+        ccLicense: testLicense,
         chooserAdaptations: 'No',
         chooserCommercial: 'Yes',
         output: testOutput
@@ -90,11 +90,11 @@ describe('generator-license-cc:chooser CC-BY-NC-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicense,
+        ccLicense: testLicense,
         chooserAdaptations: 'Yes',
         chooserCommercial: 'No',
         output: testOutput
@@ -114,11 +114,11 @@ describe('generator-license-cc:chooser CC-BY-NC-SA-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicense,
+        ccLicense: testLicense,
         chooserAdaptations: 'Share',
         chooserCommercial: 'No',
         output: testOutput
@@ -138,11 +138,11 @@ describe('generator-license-cc:chooser CC-BY-NC-ND-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicense,
+        ccLicense: testLicense,
         chooserAdaptations: 'No',
         chooserCommercial: 'No',
         output: testOutput

--- a/test/app-licenses.js
+++ b/test/app-licenses.js
@@ -28,11 +28,11 @@ describe('generator-license-cc:app CC-BY-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicenses[0],
+        ccLicense: testLicenses[0],
         output: testOutput
       }).toPromise();
   });
@@ -50,11 +50,11 @@ describe('generator-license-cc:app CC-BY-SA-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicenses[1],
+        ccLicense: testLicenses[1],
         output: testOutput
       }).toPromise();
   });
@@ -72,11 +72,11 @@ describe('generator-license-cc:app CC-BY-ND-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicenses[2],
+        ccLicense: testLicenses[2],
         output: testOutput
       }).toPromise();
   });
@@ -94,11 +94,11 @@ describe('generator-license-cc:app CC-BY-NC-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicenses[3],
+        ccLicense: testLicenses[3],
         output: testOutput
       }).toPromise();
   });
@@ -116,11 +116,11 @@ describe('generator-license-cc:app CC-BY-NC-SA-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicenses[4],
+        ccLicense: testLicenses[4],
         output: testOutput
       }).toPromise();
   });
@@ -138,11 +138,11 @@ describe('generator-license-cc:app CC-BY-NC-ND-4.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        license: testLicenses[5],
+        ccLicense: testLicenses[5],
         output: testOutput
       }).toPromise();
   });
@@ -160,8 +160,8 @@ describe('generator-license-cc:app CC0-1.0', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
-        license: testLicenses[6],
+        ccWork: testWork,
+        ccLicense: testLicenses[6],
         output: testOutput
       }).toPromise();
   });

--- a/test/app.js
+++ b/test/app.js
@@ -30,12 +30,12 @@ describe('generator-license-cc:app', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
         email: testEmail,
         website: testWebsite,
-        licensePrompt: 'Choose a License:',
-        license: testLicenses[0],
+        ccLicensePrompt: 'Choose a License:',
+        ccLicense: testLicenses[0],
         output: testOutput
       }).toPromise();
   });
@@ -50,9 +50,9 @@ describe('generator-license-cc:app no contact details', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
-        license: testLicenses[0],
+        ccLicense: testLicenses[0],
         output: testOutput
       }).toPromise();
   });
@@ -68,9 +68,9 @@ describe('generator-license-cc:app no contact details - email', function () {
       .withPrompts({
         name: testName,
         website: testWebsite,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
-        license: testLicenses[0],
+        ccLicense: testLicenses[0],
         output: testOutput
       }).toPromise();
   });
@@ -86,9 +86,9 @@ describe('generator-license-cc:app no contact details - website', function () {
       .withPrompts({
         name: testName,
         email: testEmail,
-        work: testWork,
+        ccWork: testWork,
         year: testYear,
-        license: testLicenses[0],
+        ccLicense: testLicenses[0],
         output: testOutput
       }).toPromise();
   });
@@ -103,8 +103,8 @@ describe('generator-license-cc:app no contact details + no year', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
-        license: testLicenses[0],
+        ccWork: testWork,
+        ccLicense: testLicenses[0],
         output: testOutput
       }).toPromise();
   });
@@ -118,8 +118,8 @@ describe('generator-license-cc:app pass name as option', function () {
   before(function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
-        work: testWork,
-        license: testLicenses[0],
+        ccWork: testWork,
+        ccLicense: testLicenses[0],
         output: testOutput
       }).withOptions({
         name: testName
@@ -136,8 +136,8 @@ describe('generator-license-cc:app pass email as option', function () {
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
-        license: testLicenses[0],
+        ccWork: testWork,
+        ccLicense: testLicenses[0],
         output: testOutput
       }).withOptions({
         email: testEmail
@@ -154,8 +154,8 @@ describe('generator-license-cc:app fail gracefully with invalid license', functi
     return helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
         name: testName,
-        work: testWork,
-        license: 'INVALID',
+        ccWork: testWork,
+        ccLicense: 'INVALID',
         output: testOutput
       }).withOptions({
         email: testEmail


### PR DESCRIPTION
Fixes #18 

Change option names:
- `license` is now `ccLicense`
- `licensePrompt` is now `ccLicensePrompt`
- `work` is now `ccWork`

Fix incorrect `main` in `package.json`.