### PR TITLE
add license-file test (inspired by generator-license)

### DIFF
--- a/test/test-license-files.js
+++ b/test/test-license-files.js
@@ -1,0 +1,12 @@
+'use strict';
+const assert = require('yeoman-assert');
+const licensesToTest = require('../app').licenses;
+
+describe('Ensure all valid licenses have templates', function () {
+  licensesToTest.forEach(function (license) {
+    const expectedLicenseFilename = license.value + '.txt';
+    it('license ' + license.name + ' have corresponding template file ' + expectedLicenseFilename, function () {
+      assert.file(require.resolve('../app/templates/' + expectedLicenseFilename));
+    });
+  });
+});


### PR DESCRIPTION
Checks if license files for all defined licenses exist.